### PR TITLE
Add currency format config option.

### DIFF
--- a/Source/Splitwise.gs
+++ b/Source/Splitwise.gs
@@ -98,6 +98,8 @@ function exportExpenses(expenses) {
   var allCells = sheet.getRange(3, 1, 197, 5);
   allCells.clearContent();
   allCells.setBackground("white");
+  var currencyFormat = configSheet.getRange(3, 4).getValue() || '##0.00';
+  sheet.getRangeList(["E3:E", "J3:J", "L3:16", "O3:16", "R3:16", "U16"]).setNumberFormat(currencyFormat);
   var firstCell = 3;
   for (i = 0; i < expenses.length; i++) {
     var expense = expenses[i];

--- a/Source/Splitwise.gs
+++ b/Source/Splitwise.gs
@@ -100,10 +100,16 @@ function exportExpenses(expenses) {
   allCells.setBackground("white");
   var currencyFormat = configSheet.getRange(3, 4).getValue() || '##0.00';
   sheet.getRangeList(["E3:E", "J3:J", "L3:16", "O3:16", "R3:16", "U16"]).setNumberFormat(currencyFormat);
+  const locale = SpreadsheetApp.getActiveSpreadsheet().getSpreadsheetLocale();
+  const useCommaNumberSep = useCommaDecimalSep(locale);
   var firstCell = 3;
   for (i = 0; i < expenses.length; i++) {
     var expense = expenses[i];
-    var cost = expense.cost.replace(".", ",");
+    var cost = expense.cost;
+    if (useCommaNumberSep) {
+      // Fix number format for spreadhseet locale.
+      cost = cost.replace('.', ',');
+    }
     sheet.getRange(firstCell+i, 1).setValue(expense.date);
     sheet.getRange(firstCell+i, 2).setValue(expense.category);
     sheet.getRange(firstCell+i, 3).setValue(expense.subcategory);

--- a/Source/Utils.gs
+++ b/Source/Utils.gs
@@ -1,0 +1,51 @@
+// List of locales known to use comma decimal separator.
+const localesUseCommaSep = new Set([
+  'ar_EG', // Egypt
+  'az_AZ', // Azerbajian
+  'be_BY', // Belarus
+  'bg_BG', // Bulgaria
+  'cs_CZ', // Czechia
+  'da_DK', // Denmark
+  'de_DE', // Germany
+  'el_GR', // Greece
+  'es_AR', // Argentina
+  'es_BO', // Bolivia
+  'es_CL', // Chile
+  'es_CO', // Colombia
+  'es_EC', // Ecuador
+  'es_ES', // Spain
+  'es_PY', // Paraguay
+  'es_UY', // Uruguay
+  'es_VE', // Venezuela
+  'fi_FI', // Finland
+  'fr_CA', // Canada (French)
+  'fr_FR', // France
+  'hr_HR', // Croatia
+  'hu_HU', // Hungary
+  'hy_AM', // Armenia
+  'id_ID', // Indonesia
+  'it_IT', // Italy
+  'kk_KZ', // Kazakhstan
+  'ka_GE', // Georgia
+  'lt_LT', // Lithuania
+  'lv_LV', // Latvia
+  'nb_NO', 'nn_NO', // Norway
+  'nl_NL', // Netherlands
+  'pl_PL', // Poland
+  'pt_BR', // Brazil
+  'pt_PT', // Portugal
+  'ro_RO', // Romania
+  'sk_SK', // Slovakia
+  'sl_SI', // Slovenia
+  'sr_RS', // Serbia
+  'sv_SE', // Sweden
+  'tr_TR', // Turkey
+  'ru_RU', // Russia
+  'uk_UA', // Ukraine
+  'vi_VN', // Vietnam
+]);
+
+function useCommaDecimalSep() {
+  const locale = SpreadsheetApp.getActiveSpreadsheet().getSpreadsheetLocale();
+  return localesUseCommaSep.has(locale);
+};


### PR DESCRIPTION
This adds an option to specify a number format in the config and apply it to all cells holding currency amounts.
As it needs to be synced with spreadsheet changes, the exact position may need to be adjusted. As an example see my template: https://docs.google.com/spreadsheets/d/14E9WTEvhldjyb66SIyHUm1AIGtxZpE2rt3kgAVxzHwk/edit#gid=417302492